### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build-and-test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/crispthinking/athena-python-client/security/code-scanning/4](https://github.com/crispthinking/athena-python-client/security/code-scanning/4)

The best way to fix the problem is to add a `permissions` block specifying least privilege access—most commonly `contents: read`—to either the root of the workflow or the individual job (`build-and-test`). Since there is only one job, it's sufficient and clear to add it directly beneath the job name line (`build-and-test:`), before `runs-on`. No additional imports or definitions are necessary for a YAML workflow; it's a configuration fix only. 

Specifically, in `.github/workflows/build_and_test.yml`, insert:
```yaml
permissions:
  contents: read
```
on a new line between lines 12 and 13 (immediately after `build-and-test:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
