### PR TITLE
feat: Allow Affiliate Configuration from the Environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,4 @@ OAUTH_AUDIENCE=crisp-athena-live
 
 # Athena server configuration
 # ATHENA_HOST=trust-messages.crispthinking.com
-ATHENA_AFFILIATE=crisp
+ATHENA_AFFILIATE=athena-test

--- a/examples/example.py
+++ b/examples/example.py
@@ -152,7 +152,7 @@ async def main() -> int:
         logger.error("OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET must be set")
         return 1
 
-    host = os.getenv("ATHENA_HOST", "trust-messages-global.crispthinking.com")
+    host = os.getenv("ATHENA_HOST", "trust-messages.crispthinking.com")
     affiliate = os.getenv("ATHENA_AFFILIATE", "athena-test")
     logger.info("Connecting to %s", host)
 


### PR DESCRIPTION
Update the example script to read affiliate settings from environment variables, enabling easier customization without modifying the code directly.