### PR TITLE
Fixup Athena Host Default Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ repository, or in your shell environment:
 
 You must set the following variables:
 ```
-ATHENA_HOST=your-athena-host (e.g. myathenahost.com)
+ATHENA_HOST=your-athena-host (e.g. localhost:5001)
 ATHENA_TEST_AFFILIATE=your-affiliate-id
 OAUTH_CLIENT_ID=your-oauth-client-id
 OAUTH_CLIENT_SECRET=your-oauth-client-secret

--- a/docs/api/options.rst
+++ b/docs/api/options.rst
@@ -157,7 +157,7 @@ Environment-Based Configuration
 
     # Load from environment variables
     options = AthenaOptions(
-        host=os.getenv("ATHENA_HOST", "localhost:50051"),
+        host=os.getenv("ATHENA_HOST", "trust-messages-global.crispthinking.com"),
         deployment_id=os.getenv("ATHENA_DEPLOYMENT_ID", "default"),
         resize_images=os.getenv("ATHENA_RESIZE_IMAGES", "true").lower() == "true",
         compress_images=os.getenv("ATHENA_COMPRESS_IMAGES", "true").lower() == "true",

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -48,7 +48,7 @@ This example shows:
             "OAUTH_AUTH_URL", "https://crispthinking.auth0.com/oauth/token"
         )
         audience = os.getenv("OAUTH_AUDIENCE", "crisp-athena-live")
-        host = os.getenv("ATHENA_HOST", "localhost")
+        host = os.getenv("ATHENA_HOST", "trust-messages-global.crispthinking.com")
 
         # Create credential helper
         credential_helper = CredentialHelper(

--- a/examples/classify_single_example.py
+++ b/examples/classify_single_example.py
@@ -203,7 +203,7 @@ async def main() -> int:
         logger.error("OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET must be set")
         return 1
 
-    host = os.getenv("ATHENA_HOST", "localhost")
+    host = os.getenv("ATHENA_HOST", "trust-messages-global.crispthinking.com")
     logger.info("Connecting to %s", host)
 
     # Create credential helper

--- a/examples/example.py
+++ b/examples/example.py
@@ -152,7 +152,7 @@ async def main() -> int:
         logger.error("OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET must be set")
         return 1
 
-    host = os.getenv("ATHENA_HOST", "trust-messages.crispthinking.com")
+    host = os.getenv("ATHENA_HOST", "trust-messages-global.crispthinking.com")
     affiliate = os.getenv("ATHENA_AFFILIATE", "athena-test")
     logger.info("Connecting to %s", host)
 


### PR DESCRIPTION
This pull request updates the default value for the `ATHENA_HOST` environment variable across documentation and example files to use `trust-messages-global.crispthinking.com` instead of previous values like `localhost` or `trust-messages.crispthinking.com`. This change ensures consistency and directs users to the correct global Athena host endpoint.

**Environment variable defaults updated:**

* Documentation:
  - Changed the example value for `ATHENA_HOST` in `README.md` to `localhost:5001` for clarity.
  - Updated the default value for `ATHENA_HOST` in `docs/api/options.rst` and `docs/examples.rst` to `trust-messages-global.crispthinking.com`. [[1]](diffhunk://#diff-d01172d77c0c958b2e628bee5edba92a3970041b67f20157cdfb7a768c9b4c30L160-R160) [[2]](diffhunk://#diff-5311c1419ec81d9fdb5cbfdb6e595afcac980d90e3e508c34b592595564d386fL51-R51)

* Example scripts:
  - Updated the default value for `ATHENA_HOST` in `examples/classify_single_example.py` and `examples/example.py` to `trust-messages-global.crispthinking.com`. [[1]](diffhunk://#diff-7bb97ee87c7e7029689c62748b7c58f8f14643718d271e76a5b0c24957d59967L206-R206) [[2]](diffhunk://#diff-9fb5aadb45b410c48744b000c6720e4361d8d32948f81b145cd4e3b9abd177d4L155-R155)