### PR TITLE
feat: add mark to allow for excluding e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,10 @@ Then run the functional tests with:
 ```bash
 pytest -m functional
 ```
+
+To exclude the e2e tests, which require usage of the live classifier and
+therefore are unsuitable for regular development runs, use:
+
+```bash
+pytest -m 'functional and not e2e'
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ reportAny = false
 [tool.pytest.ini_options]
 markers = [
     "functional: mark a test as a functional test",
+    "e2e: mark a test as an end-to-end test which asserts expected scores for known inputs. These tests should only be considered authoritative against the live classifier."
 ]
 addopts = "--strict-markers"
 

--- a/tests/functional/e2e/test_classify_single.py
+++ b/tests/functional/e2e/test_classify_single.py
@@ -21,6 +21,7 @@ FP_ERROR_TOLERANCE = 1e-4
 
 @pytest.mark.asyncio
 @pytest.mark.functional
+@pytest.mark.e2e
 @pytest.mark.parametrize("test_case", TEST_CASES, ids=lambda tc: tc.id)
 async def test_classify_single(
     athena_options: AthenaOptions,


### PR DESCRIPTION
This PR adds a new 'e2e' mark which goes on the e2e test cases, to allow for easily excluding the e2e test cases which do not make sense to be run against a development environment.