### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import uuid
 from asyncio import Future, Queue, Task, create_task


### PR DESCRIPTION
Use a single import style for `asyncio` in `tests/functional/conftest.py`.  
The least invasive fix is to remove `import asyncio` (line 1) and keep the existing `from asyncio import Future, Queue, Task, create_task` import, since the latter already provides the symbols used for typing/task creation in this file.

Change needed:
- **File**: `tests/functional/conftest.py`
- **Region**: top import block
- **Edit**: delete `import asyncio` line only; keep all other imports unchanged.

No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._